### PR TITLE
Split book stores

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -32,7 +32,6 @@
 
   onMounted(() => {
     if (props.error) {
-      console.log(props.error);
       toast.add({
         severity: ToastSeverity.WARN,
         summary: props.error.status,

--- a/src/api/books.ts
+++ b/src/api/books.ts
@@ -1,6 +1,6 @@
 import axios from '@/axios';
 
-import { type Book } from '@/types/books';
+import { type BookInList } from '@/types/books';
 
 type OrderResponse = {
   orderId: number;
@@ -28,7 +28,7 @@ export const getBooks = async ({ query, available, reservedByMe }: BookQueryPara
     url += `?reserved_by_me`;
   }
 
-  return (await axios.get(url)).data as Book[];
+  return (await axios.get(url)).data as BookInList[];
 };
 
 export const getBook = async (id: number) => {

--- a/src/components/BookList.vue
+++ b/src/components/BookList.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-  import type { BookReserved } from '@/types/books';
+  import type { BookInList, BookReserved } from '@/types/books';
   import BookCover from './BookCover.vue';
 
   defineProps<{
-    books: BookReserved[];
+    books: BookInList[] | BookReserved[];
     showTerm?: boolean;
     showReservationId?: boolean;
   }>();

--- a/src/components/GoBack.vue
+++ b/src/components/GoBack.vue
@@ -9,7 +9,7 @@
 </script>
 
 <template>
-  <a class="link mb-5 inline-flex items-center hover:no-underline" @click="goBack">
+  <a href="" class="link mb-5 inline-flex items-center hover:no-underline" @click.prevent="goBack">
     <i class="pi pi-arrow-left mr-2"></i>
     Back
   </a>

--- a/src/components/SingleBook.vue
+++ b/src/components/SingleBook.vue
@@ -1,10 +1,5 @@
 <script setup lang="ts">
-  import { useRouter } from 'vue-router';
-  import { useToast } from 'primevue/usetoast';
-  import { ToastSeverity } from 'primevue/api';
-
   import type { Book } from '@/types/books';
-  import useAuth from '@/stores/auth';
   import useBook from '@/stores/book';
   import BookCover from '@/components/BookCover.vue';
   import BookIcon from '@/components/icons/BookIcon.vue';
@@ -12,33 +7,12 @@
 
   defineProps<{
     book: Book;
+    orderProcessing: boolean;
+    onOrder: () => void;
+    onOrderCancel: () => void;
   }>();
 
   const bookStore = useBook();
-  const auth = useAuth();
-  const router = useRouter();
-  const toast = useToast();
-
-  const checkAuth = () => {
-    if (auth.loggedOut) {
-      toast.add({ severity: ToastSeverity.WARN, detail: 'Please, login first', life: 3000 });
-      router.push({ name: 'login', query: { redirect: router.currentRoute.value.fullPath } });
-      return false;
-    }
-    return true;
-  };
-
-  const order = (bookId: int) => {
-    if (checkAuth()) {
-      bookStore.order(bookId);
-    }
-  };
-
-  const orderCancel = (bookId: int) => {
-    if (checkAuth()) {
-      bookStore.orderCancel(bookId);
-    }
-  };
 </script>
 
 <template>
@@ -66,8 +40,8 @@
 
       <button
         v-if="bookStore.reservable"
-        :disabled="book.isMaxReservationsReached"
-        @click="order(book.id)"
+        :disabled="book.isMaxReservationsReached || orderProcessing"
+        @click="onOrder(book.id)"
         class="transition-background-color mr-2 mt-2 rounded bg-primary-400 p-3 text-white enabled:hover:bg-primary-300 disabled:opacity-75">
         <span v-if="bookStore.queuable">Queue up</span>
         <span v-else>Reserve</span>
@@ -77,7 +51,7 @@
       </span>
       <CancelButton
         v-if="book.isReservedByMember || book.isQueuedByMember"
-        @click="orderCancel(book.id)">
+        @click="onOrderCancel(book.id)">
         Cancel reservation
       </CancelButton>
     </aside>

--- a/src/stores/book.ts
+++ b/src/stores/book.ts
@@ -1,0 +1,81 @@
+import { ToastSeverity } from 'primevue/api';
+import { defineStore } from 'pinia';
+
+import type { Book } from '@/types/books';
+import { getBook, orderBook, cancelBookOrder } from '@/api/books';
+
+interface State {
+  book: Book;
+
+  reservedByAnyone: () => boolean;
+  reservable: () => boolean;
+  bookedByMember: () => boolean;
+  queuable: () => boolean;
+}
+
+const useBook = defineStore('book', {
+  state: (): State => {
+    return {
+      book: {},
+    };
+  },
+
+  getters: {
+    reservedByAnyone() {
+      return !this.book.isAvailable;
+    },
+
+    bookedByMember() {
+      return this.book.isReservedByMember || this.book.isQueuedByMember || this.book.isIssuedToMember;
+    },
+
+    reservable(): boolean {
+      return !this.bookedByMember;
+    },
+
+    queuable(): boolean {
+      return this.reservedByAnyone && !this.bookedByMember;
+    }
+  },
+
+  actions: {
+    addToast(detail: string, severity: ToastSeverity = ToastSeverity.SUCCESS) {
+      window.$toast.add({
+        severity,
+        detail: detail,
+        life: 3000,
+      });
+    },
+
+    async order(id: number): void {
+      const { detail } = await orderBook(id);
+      if (this.book.isReserved || this.book.isIssued) {
+        this.book.isQueuedByMember = true;
+      } else {
+        this.book.isReserved = true;
+        this.book.isReservedByMember = true;
+      }
+      this.book.isAvailable = false;
+      this.addToast(detail);
+    },
+
+    async orderCancel(id: number): void {
+      await cancelBookOrder(id);
+      if (this.book.isReservedByMember || this.book.isQueuedByMember) {
+        this.book.isAvailable = true;
+        this.book.isReserved = false;
+      }
+      this.book.isQueuedByMember = false;
+      this.book.isReservedByMember = false;
+      this.book.isIssuedToMember = false;
+      this.book.isMaxReservationsReached = false;
+      this.addToast('Reservation cancelled', ToastSeverity.WARN);
+    },
+
+    async get(id: number): Book {
+      this.book = await getBook(id);
+      return this.book;
+    },
+  },
+});
+export default useBook;

--- a/src/stores/book.ts
+++ b/src/stores/book.ts
@@ -49,26 +49,11 @@ const useBook = defineStore('book', {
 
     async order(id: number): void {
       const { detail } = await orderBook(id);
-      if (this.book.isReserved || this.book.isIssued) {
-        this.book.isQueuedByMember = true;
-      } else {
-        this.book.isReserved = true;
-        this.book.isReservedByMember = true;
-      }
-      this.book.isAvailable = false;
       this.addToast(detail);
     },
 
     async orderCancel(id: number): void {
       await cancelBookOrder(id);
-      if (this.book.isReservedByMember || this.book.isQueuedByMember) {
-        this.book.isAvailable = true;
-        this.book.isReserved = false;
-      }
-      this.book.isQueuedByMember = false;
-      this.book.isReservedByMember = false;
-      this.book.isIssuedToMember = false;
-      this.book.isMaxReservationsReached = false;
       this.addToast('Reservation cancelled', ToastSeverity.WARN);
     },
 

--- a/src/stores/books.ts
+++ b/src/stores/books.ts
@@ -1,12 +1,12 @@
 import { ToastSeverity } from 'primevue/api';
 import { defineStore } from 'pinia';
 
-import type { Book } from '@/types/books';
+import type { BookInList, BookReserved } from '@/types/books';
 import { getBooks } from '@/api/books';
 
 interface State {
-  items: Book[];
-  available: Book[];
+  items: BookInList[];
+  available: BookInList[];
   reserved: BookReserved[];
 }
 
@@ -28,19 +28,19 @@ const useBooks = defineStore('books', {
       });
     },
 
-    setBooks(books: Book[]): void {
+    setBooks(books: BookInList[]): void {
       this.items = books;
     },
 
-    setAvailable(books: Book[]): void {
+    setAvailable(books: BookInList[]): void {
       this.available = books;
     },
 
-    setMemberReserved(books: Book[]): void {
+    setMemberReserved(books: BookReserved[]): void {
       this.reserved = books;
     },
 
-    async list(): Book[] {
+    async list(): BookInList[] {
       if (this.items.length > 0) {
         return this.items;
       }
@@ -49,19 +49,19 @@ const useBooks = defineStore('books', {
       return this.items;
     },
 
-    async listAvailable(): Book[] {
+    async listAvailable(): BookInList[] {
       const books = await getBooks({ available: true });
       this.setAvailable(books);
       return this.available;
     },
 
-    async search(query: string): Book[] {
+    async search(query: string): BookInList[] {
       const books = await getBooks({ query });
       this.setBooks(books);
       return this.items;
     },
 
-    async listReservedByMember(): Book[] {
+    async listReservedByMember(): BookReserved[] {
       const books = await getBooks({ reservedByMe: true });
       this.setMemberReserved(books);
       return this.reserved;

--- a/src/types/books.ts
+++ b/src/types/books.ts
@@ -19,17 +19,16 @@ export interface Book {
   isbn: string;
   pages: number;
   pagesDescription: string;
+  coverImageUrl: string;
+  reservationTerm: Date | null;
   isAvailable: boolean;
   isIssued: boolean;
   isReserved: boolean;
   isIssuedToMember: boolean;
   isQueuedByMember: boolean;
   isReservedByMember: boolean;
-  reservationTerm: Date | null;
-  maxReservationsReached: boolean;
-  coverImageUrl: string;
+  isMaxReservationsReached: boolean;
 }
-
 export interface BookReserved {
   id: number;
   title: string;

--- a/src/types/books.ts
+++ b/src/types/books.ts
@@ -29,14 +29,17 @@ export interface Book {
   isReservedByMember: boolean;
   isMaxReservationsReached: boolean;
 }
-export interface BookReserved {
+export interface BookInList {
   id: number;
-  title: string;
   author: Author;
+  title: string;
+  coverImageUrl: string;
+}
+
+export interface BookReserved extends BookInList {
   pages: string;
   reservationTerm: Date;
   reservationId: number;
-  coverImageUrl: string;
   isAvailable: string;
   isIssued: string;
 }

--- a/src/views/BookView.vue
+++ b/src/views/BookView.vue
@@ -1,18 +1,19 @@
 <script setup lang="ts">
+  import type { Book as BookType } from '@/types/books';
   import { ref, watch } from 'vue';
   import { useRoute } from 'vue-router';
-  import useBooks from '@/stores/books';
+  import useBook from '@/stores/book';
   import Book from '@/components/SingleBook.vue';
   import Spinner from '@/components/Spinner.vue';
   import GoBack from '@/components/GoBack.vue';
 
-  const books = useBooks();
-  const route = useRoute();
-  const book = ref(null);
+  const book = ref({}) as BookType;
   const loading = ref(true);
+  const bookStore = useBook();
+  const route = useRoute();
 
   const fetchBook = async (id: number) => {
-    book.value = await books.get(id);
+    book.value = await bookStore.get(id);
     loading.value = false;
   };
   watch(() => route.params.id, fetchBook, { immediate: true });

--- a/src/views/Layout.vue
+++ b/src/views/Layout.vue
@@ -10,16 +10,19 @@
   const auth = useAuth();
   const accountMenu = ref(null);
   const menuIconToggled = ref(false);
+  const username = ref(auth.user?.username);
+
+  auth.$subscribe((_, state) => {
+    username.value = state.user?.username;
+  });
 
   const toggleIcon = () => {
     menuIconToggled.value = !menuIconToggled.value;
   };
 
-  const username = auth.user?.username;
-
   const accountMenuItems = ref([
     {
-      label: `Account (${username})`,
+      label: () => `Account (${username.value})`,
       command: () => router.push({ name: 'account' }),
     },
     {

--- a/src/views/Layout.vue
+++ b/src/views/Layout.vue
@@ -15,9 +15,11 @@
     menuIconToggled.value = !menuIconToggled.value;
   };
 
+  const username = auth.user?.username;
+
   const accountMenuItems = ref([
     {
-      label: 'Account',
+      label: `Account (${username})`,
       command: () => router.push({ name: 'account' }),
     },
     {


### PR DESCRIPTION
Adds/refactors:
- book and books stores separated
- order/cancel order performed from book view instead + book state re-fetched from backend afterward.
- username reference in the account menu
- Focusable go-back link