### PR TITLE
Display Reserved & Enqueued books separately

### DIFF
--- a/src/components/BookList.vue
+++ b/src/components/BookList.vue
@@ -1,11 +1,9 @@
 <script setup lang="ts">
-  import type { BookInList, BookReserved } from '@/types/books';
+  import type { BookInList, BookReserved, BookEnqueued } from '@/types/books';
   import BookCover from './BookCover.vue';
 
   defineProps<{
-    books: BookInList[] | BookReserved[];
-    showTerm?: boolean;
-    showReservationId?: boolean;
+    books: Array<BookInList | BookReserved | BookEnqueued>;
   }>();
 </script>
 
@@ -20,13 +18,23 @@
       </RouterLink>
       <span v-if="book.author">{{ book.author.lastName }}, {{ book.author.firstName }}</span>
       <div class="mt-2">
-        <em v-if="showTerm && book.isIssued">
-          <span>Issued until: {{ book.reservationTerm }}</span>
+        <em v-if="book.reservationTerm">
+          <span v-if="book.reservationId">
+            Issued to you until: <br />
+            {{ book.reservationTerm }}
+          </span>
+          <span v-else>
+            Issued to reader until: <br />
+            {{ book.reservationTerm }}
+          </span>
           <br />
         </em>
-        <em v-if="showReservationId" class="text-sm font-semibold"
-          >Reservation ID: {{ book.reservationId }}</em
-        >
+        <em v-if="book.reservationId" class="text-sm font-semibold">
+          Reservation ID: {{ book.reservationId }}
+        </em>
+        <em v-else-if="!book.reservationId && book.amountInQueue" class="text-sm font-semibold">
+          Amount in queue: {{ book.amountInQueue }}
+        </em>
       </div>
     </li>
   </ul>

--- a/src/components/SingleBook.vue
+++ b/src/components/SingleBook.vue
@@ -24,33 +24,47 @@
         </template>
       </BookCover>
       <div>
-        Status:
-        <em v-if="book.isAvailable">On shelf</em>
-        <em v-else-if="book.isReservedByMember">Reserved by you</em>
-        <em v-else-if="book.isIssued">
-          <span v-if="book.isIssuedToMember">Issued to you until: {{ book.reservationTerm }}</span>
-          <span v-else>
-            Issued until: {{ book.reservationTerm }}
-            <span v-if="book.isQueuedByMember">(Enqueued by you)</span>
-          </span>
-        </em>
-        <em v-else-if="book.isQueuedByMember">Enqueued by you</em>
-        <em v-else-if="book.isReserved">Reserved</em>
+        <div>
+          <em v-if="book.isAvailable">On shelf</em>
+          <em v-else-if="book.isReservedByMember">Reserved by you</em>
+          <em v-else-if="book.isIssued">
+            <span v-if="book.isIssuedToMember">
+              Issued to you until: <br />
+              {{ book.reservationTerm }}
+            </span>
+            <span v-else>
+              Issued to reader until: <br />
+              {{ book.reservationTerm }} <br />
+            </span>
+          </em>
+          <em v-else-if="book.isEnqueuedByMember">Enqueued by you</em>
+          <em v-else-if="book.isReserved">Reserved</em>
+        </div>
+        <span v-if="!book.isIssuedToMember && book.amountInQueue"
+          >Amount in queue: {{ book.amountInQueue }}
+        </span>
       </div>
 
       <button
         v-if="bookStore.reservable"
-        :disabled="book.isMaxReservationsReached || orderProcessing"
+        :disabled="
+          book.isMaxReservationsReached || book.isMaxEnqueuedOrdersReached || orderProcessing
+        "
         @click="onOrder(book.id)"
         class="transition-background-color mr-2 mt-2 rounded bg-primary-400 p-3 text-white enabled:hover:bg-primary-300 disabled:opacity-75">
         <span v-if="bookStore.queuable">Queue up</span>
         <span v-else>Reserve</span>
       </button>
       <span v-if="book.isMaxReservationsReached && !bookStore.bookedByMember" class="block text-xs">
-        Maximum reserations reached
+        Maximum reservations reached
+      </span>
+      <span
+        v-if="book.isMaxEnqueuedOrdersReached && !bookStore.bookedByMember"
+        class="block text-xs">
+        Maximum reservations in queue reached
       </span>
       <CancelButton
-        v-if="book.isReservedByMember || book.isQueuedByMember"
+        v-if="book.isReservedByMember || book.isEnqueuedByMember"
         :disabled="orderProcessing"
         @click="onOrderCancel(book.id)">
         Cancel reservation

--- a/src/stores/book.ts
+++ b/src/stores/book.ts
@@ -27,7 +27,7 @@ const useBook = defineStore('book', {
 
     bookedByMember() {
       return (
-        this.book.isReservedByMember || this.book.isQueuedByMember || this.book.isIssuedToMember
+        this.book.isReservedByMember || this.book.isEnqueuedByMember || this.book.isIssuedToMember
       );
     },
 

--- a/src/stores/books.ts
+++ b/src/stores/books.ts
@@ -8,6 +8,7 @@ interface State {
   items: BookInList[];
   available: BookInList[];
   reserved: BookReserved[];
+  enqueued: BookEnqueued[];
 }
 
 const useBooks = defineStore('books', {
@@ -16,6 +17,7 @@ const useBooks = defineStore('books', {
       items: [],
       available: [],
       reserved: [],
+      enqueued: [],
     };
   },
 

--- a/src/types/books.ts
+++ b/src/types/books.ts
@@ -25,9 +25,11 @@ export interface Book {
   isIssued: boolean;
   isReserved: boolean;
   isIssuedToMember: boolean;
-  isQueuedByMember: boolean;
+  isEnqueuedByMember: boolean;
   isReservedByMember: boolean;
   isMaxReservationsReached: boolean;
+  isMaxEnqueuedOrdersReached: boolean;
+  amountInQueue: number;
 }
 export interface BookInList {
   id: number;
@@ -37,9 +39,15 @@ export interface BookInList {
 }
 
 export interface BookReserved extends BookInList {
-  pages: string;
   reservationTerm: Date;
-  reservationId: number;
-  isAvailable: string;
-  isIssued: string;
+  reservationId: number | null;
+  isIssued: boolean | null;
+  isEnqueuedByMember: null;
+}
+
+export interface BookEnqueued extends BookReserved {
+  reservationTerm: null;
+  reservationId: null;
+  isEnqueuedByMember: boolean;
+  amountInQueue: number;
 }

--- a/src/views/Reservations.vue
+++ b/src/views/Reservations.vue
@@ -8,11 +8,21 @@
   import { useRouter } from 'vue-router';
 
   const loading = ref(true);
-  const books = ref([]);
+  const reservedBooks = ref([]);
+  const enqueuedBooks = ref([]);
+  const hasReservations = ref(false);
   const router = useRouter();
 
   const fetchReservedBooks = async () => {
-    books.value = await useBooks().listReservedByMember();
+    const allReservations = await useBooks().listReservedByMember();
+    hasReservations.value = allReservations.length > 0;
+    allReservations.forEach((book) => {
+      if (book.reservationId) {
+        reservedBooks.value.push(book);
+      } else {
+        enqueuedBooks.value.push(book);
+      }
+    });
     loading.value = false;
   };
   watch(() => null, fetchReservedBooks, { immediate: true });
@@ -25,11 +35,18 @@
   <main>
     <Spinner v-if="loading" />
     <div v-else>
-      <h2 v-if="!books.length">
+      <h2 v-if="!hasReservations">
         No reservations, check out books:
         <a href="" @click.prevent="router.push({ name: 'books' })" class="link">here</a>
       </h2>
-      <BookList :books="books" :showTerm="true" :showReservationId="true" />
+      <div v-if="reservedBooks.length" class="mb-20">
+        <h2 class="mb-4 text-center">Reserved books</h2>
+        <BookList :books="reservedBooks" />
+      </div>
+      <div v-if="enqueuedBooks.length">
+        <h2 class="mb-4 text-center">Enqueued books</h2>
+        <BookList :books="enqueuedBooks" />
+      </div>
     </div>
   </main>
 </template>


### PR DESCRIPTION
Related backend: https://github.com/peacefulseeker/django-libraryms/pull/20


Unless a member has an issued book like below, the number of people in queue will be displayed
<img width="255" alt="Screenshot 2024-08-18 at 10 05 40" src="https://github.com/user-attachments/assets/bf52eb84-23ef-4864-8b6d-41dd7703d246">


![Screenshot 2024-08-18 at 10 06 27](https://github.com/user-attachments/assets/e2e06f51-a6e3-442a-9e2c-4f211fc58896)
![Screenshot 2024-08-18 at 10 06 42](https://github.com/user-attachments/assets/370a4c70-1139-4244-bbfd-b27147b79857)

