### PR TITLE
CI/CD with versioned deploy to S3 / Cloudfront

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -25,7 +25,7 @@ runs:
       shell: bash
     - name: Generate assets version number
       id: version
-      run: echo "::set-output name=version::$(git rev-parse --short HEAD)"
+      run: echo "version=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       shell: bash
     - name: Build
       run: CLOUDFRONT_ASSETS_VERSION=${{ steps.version.outputs.version }} pnpm run build

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,0 +1,32 @@
+name: 'Setup and build'
+description: 'Sets up node, pnpm, installs dependencies, and builds the project'
+inputs:
+  node-version:
+    description: 'Node.js version to use'
+    required: true
+    default: '20.9.0'
+  pnpm-version:
+    description: 'pnpm version to use'
+    required: true
+    default: '9.9.0'
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ inputs.node-version }}
+    - name: Install pnpm
+      uses: pnpm/action-setup@v2
+      with:
+        version: ${{ inputs.pnpm-version }}
+    - name: Install dependencies
+      run: pnpm install
+      shell: bash
+    - name: Generate assets version number
+      id: version
+      run: echo "::set-output name=version::$(git rev-parse --short HEAD)"
+      shell: bash
+    - name: Build
+      run: CLOUDFRONT_ASSETS_VERSION=${{ steps.version.outputs.version }} pnpm run build
+      shell: bash

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -23,10 +23,9 @@ runs:
     - name: Install dependencies
       run: pnpm install
       shell: bash
-    - name: Generate assets version number
-      id: version
-      run: echo "version=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+    - name: Generate version number
+      run: echo "CLOUDFRONT_ASSETS_VERSION=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
       shell: bash
     - name: Build
-      run: CLOUDFRONT_ASSETS_VERSION=${{ steps.version.outputs.version }} pnpm run build
+      run: pnpm run build
       shell: bash

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -25,8 +25,11 @@ runs:
       shell: bash
     - name: Generate version number
       run: |
-        TIMESTAMP=$(date +%Y%m%d%H%M | rev)
-        echo "CLOUDFRONT_ASSETS_VERSION=${TIMESTAMP}_$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+        if [ -z "$CLOUDFRONT_ASSETS_VERSION" ]; then
+          echo "SETTING CLOUDFRONT_ASSETS_VERSION"
+          TIMESTAMP=$(date +%Y%m%d%H%M)
+          echo "CLOUDFRONT_ASSETS_VERSION=${TIMESTAMP}_$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+        fi
       shell: bash
     - name: Build
       run: pnpm run build

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,36 +1,20 @@
 name: 'Setup and build'
 description: 'Sets up node, pnpm, installs dependencies, and builds the project'
-inputs:
-  node-version:
-    description: 'Node.js version to use'
-    required: true
-    default: '20.9.0'
-  pnpm-version:
-    description: 'pnpm version to use'
-    required: true
-    default: '9.9.0'
 runs:
   using: "composite"
   steps:
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: ${{ inputs.node-version }}
+        node-version: 20.9.0
     - name: Install pnpm
       uses: pnpm/action-setup@v4
       with:
-        version: ${{ inputs.pnpm-version }}
+        version: 9.9.0
     - name: Install dependencies
       run: pnpm install
       shell: bash
-    - name: Generate version number
-      run: |
-        if [ -z "$CLOUDFRONT_ASSETS_VERSION" ]; then
-          echo "SETTING CLOUDFRONT_ASSETS_VERSION"
-          TIMESTAMP=$(date +%Y%m%d%H%M)
-          echo "CLOUDFRONT_ASSETS_VERSION=${TIMESTAMP}_$(git rev-parse --short HEAD)" >> $GITHUB_ENV
-        fi
-      shell: bash
+
     - name: Build
       run: pnpm run build
       shell: bash

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -24,7 +24,9 @@ runs:
       run: pnpm install
       shell: bash
     - name: Generate version number
-      run: echo "CLOUDFRONT_ASSETS_VERSION=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+      run: |
+        TIMESTAMP=$(date +%Y%m%d%H%M)
+        echo "CLOUDFRONT_ASSETS_VERSION=${TIMESTAMP}_$(git rev-parse --short HEAD)" >> $GITHUB_ENV
       shell: bash
     - name: Build
       run: pnpm run build

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -25,7 +25,7 @@ runs:
       shell: bash
     - name: Generate version number
       run: |
-        TIMESTAMP=$(date +%Y%m%d%H%M)
+        TIMESTAMP=$(date +%Y%m%d%H%M | rev)
         echo "CLOUDFRONT_ASSETS_VERSION=${TIMESTAMP}_$(git rev-parse --short HEAD)" >> $GITHUB_ENV
       shell: bash
     - name: Build

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -13,11 +13,11 @@ runs:
   using: "composite"
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
     - name: Install pnpm
-      uses: pnpm/action-setup@v2
+      uses: pnpm/action-setup@v4
       with:
         version: ${{ inputs.pnpm-version }}
     - name: Install dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: ./.github/actions/build
 
   lint-and-type-check:
-    needs: build
+    needs: [generate-assets-version, build]
     runs-on: ubuntu-latest
     env:
       CLOUDFRONT_ASSETS_VERSION: ${{ needs.generate-assets-version.outputs.cloudfront_assets_version }}
@@ -48,7 +48,7 @@ jobs:
         run: pnpm check:type
 
   test:
-    needs: lint-and-type-check
+    needs: [generate-assets-version, lint-and-type-check]
     runs-on: ubuntu-latest
     env:
       CLOUDFRONT_ASSETS_VERSION: ${{ needs.generate-assets-version.outputs.cloudfront_assets_version }}
@@ -59,7 +59,7 @@ jobs:
         run: pnpm test
 
   deploy:
-    needs: test
+    needs: [generate-assets-version, test]
     runs-on: ubuntu-latest
     env:
       CLOUDFRONT_ASSETS_VERSION: ${{ needs.generate-assets-version.outputs.cloudfront_assets_version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+env:
+  GITHUB_CONTEXT: ${{ toJson(github) }}
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,6 +52,7 @@ jobs:
         run: pnpm test
 
   deploy:
+    if: github.ref == 'refs/heads/main' && github.repository_owner == 'peacefulseeker'
     needs: [generate-assets-version, test]
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,50 +12,44 @@ env:
   GITHUB_CONTEXT: ${{ toJson(github) }}
 
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/build
 
-    - name: Setup Node.js
-      uses: actions/setup-node@v3
-      with:
-        node-version: 20.9.0
+  lint-and-type-check:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/build
+      - name: Lint
+        run: pnpm check:lint
+      - name: Type check
+        run: pnpm check:type
 
-    - name: Install pnpm
-      uses: pnpm/action-setup@v2
-      with:
-        version: 9.9.0
+  test:
+    needs: lint-and-type-check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/build
+      - name: Run tests
+        run: pnpm test
 
-    - name: Install dependencies
-      run: pnpm install
-
-    - name: Generate version number
-      id: version
-      run: echo "::set-output name=version::$(git rev-parse --short HEAD)"
-
-    - name: build
-      run: CLOUDFRONT_ASSETS_VERSION=${{ steps.version.outputs.version }} pnpm run build
-
-    - name: lint
-      run: pnpm check:lint
-
-    - name: type check
-      run: pnpm check:type
-
-    - name: Run tests
-      run: pnpm test
-
-    - name: Authorize AWS
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: eu-central-1
-
-    - name: Deploy to S3
-      run: |
-        VERSION=${{ steps.version.outputs.version }}
-        aws s3 sync dist/ s3://django-libraryms/v/$VERSION --delete --acl public-read
-        # aws cloudfront create-invalidation --distribution-id YOUR_DISTRIBUTION_ID --paths "/v/$VERSION/*"
+  deploy:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Authorize AWS
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-central-1
+      - name: Deploy to S3
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          aws s3 sync dist/ s3://django-libraryms/v/$VERSION --delete --acl public-read

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,8 +12,23 @@ env:
   GITHUB_CONTEXT: ${{ toJson(github) }}
 
 jobs:
-  build:
+  generate-assets-version:
     runs-on: ubuntu-latest
+    outputs:
+      cloudfront_assets_version: ${{ steps.set_version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: set_version
+        run: |
+          TIMESTAMP=$(date +%Y%m%d%H%M)
+          VERSION=$(git rev-parse --short HEAD)
+          echo "version=${TIMESTAMP}_${VERSION}" >> $GITHUB_OUTPUT
+
+  build:
+    needs: generate-assets-version
+    runs-on: ubuntu-latest
+    env:
+      CLOUDFRONT_ASSETS_VERSION: ${{ needs.generate-version.outputs.cloudfront_assets_version }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/build
@@ -21,6 +36,8 @@ jobs:
   lint-and-type-check:
     needs: build
     runs-on: ubuntu-latest
+    env:
+      CLOUDFRONT_ASSETS_VERSION: ${{ needs.generate-version.outputs.cloudfront_assets_version }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/build
@@ -32,6 +49,8 @@ jobs:
   test:
     needs: lint-and-type-check
     runs-on: ubuntu-latest
+    env:
+      CLOUDFRONT_ASSETS_VERSION: ${{ needs.generate-version.outputs.cloudfront_assets_version }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/build
@@ -41,6 +60,8 @@ jobs:
   deploy:
     needs: test
     runs-on: ubuntu-latest
+    env:
+      CLOUDFRONT_ASSETS_VERSION: ${{ needs.generate-version.outputs.cloudfront_assets_version }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,5 +52,4 @@ jobs:
           aws-region: eu-central-1
       - name: Deploy to S3
         run: |
-          VERSION=${{ steps.version.outputs.version }}
-          aws s3 sync dist/ s3://django-libraryms/v/$VERSION --delete --acl public-read
+          aws s3 sync dist/ s3://django-libraryms/v/{env.CLOUDFRONT_ASSETS_VERSION} --delete --acl public-read

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,4 +52,4 @@ jobs:
           aws-region: eu-central-1
       - name: Deploy to S3
         run: |
-          aws s3 sync dist/ s3://django-libraryms/v/{env.CLOUDFRONT_ASSETS_VERSION} --delete --acl public-read
+          aws s3 sync dist/ s3://django-libraryms/v/${{ env.CLOUDFRONT_ASSETS_VERSION }} --delete --acl public-read

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/build
       - name: Authorize AWS
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,13 +36,13 @@ jobs:
       run: CLOUDFRONT_ASSETS_VERSION=${{ steps.version.outputs.version }} pnpm run build
 
     - name: lint
-      run: pnpm run lint
+      run: pnpm check:lint
 
     - name: type check
-      run: pnpm run type-check
+      run: pnpm check:type
 
     - name: Run tests
-      run: pnpm run test
+      run: pnpm test
 
     - name: Authorize AWS
       if: github.ref == 'refs/heads/main' && github.repository_owner == 'peacefulseeker'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,8 +9,7 @@ on:
       - main
 
 jobs:
-  generate-assets-version:
-    if: github.ref == 'refs/heads/main' && github.repository_owner == 'peacefulseeker'
+  build:
     runs-on: ubuntu-latest
     outputs:
       cloudfront_assets_version: ${{ steps.set_version.outputs.cloudfront_assets_version }}
@@ -21,16 +20,6 @@ jobs:
           TIMESTAMP=$(date +%Y%m%d%H%M)
           VERSION=$(git rev-parse --short HEAD)
           echo "cloudfront_assets_version=${TIMESTAMP}_${VERSION}" >> $GITHUB_OUTPUT
-
-  build:
-    needs:
-      - ${{ github.ref == 'refs/heads/main' && 'generate-assets-version' || '' }}
-    runs-on: ubuntu-latest
-    env:
-      GEN_ASSETS_OUTPUTS: ${{join(needs.generate-assets-version.outputs.*, '\n')}}
-      CLOUDFRONT_ASSETS_VERSION: ${{ needs.generate-assets-version.outputs.cloudfront_assets_version }}
-    steps:
-      - uses: actions/checkout@v4
       - uses: ./.github/actions/build
 
   lint-and-type-check:
@@ -54,11 +43,11 @@ jobs:
         run: pnpm test
 
   deploy:
-    if: github.ref == 'refs/heads/main' && github.repository_owner == 'peacefulseeker'
-    needs: [generate-assets-version, test]
+    # if: github.ref == 'refs/heads/main' && github.repository_owner == 'peacefulseeker'
+    needs: [build, test]
     runs-on: ubuntu-latest
     env:
-      CLOUDFRONT_ASSETS_VERSION: ${{ needs.generate-assets-version.outputs.cloudfront_assets_version }}
+      CLOUDFRONT_ASSETS_VERSION: ${{ needs.build.outputs.cloudfront_assets_version }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,10 +35,8 @@ jobs:
       - uses: ./.github/actions/build
 
   lint-and-type-check:
-    needs: [generate-assets-version, build]
+    needs: build
     runs-on: ubuntu-latest
-    env:
-      CLOUDFRONT_ASSETS_VERSION: ${{ needs.generate-assets-version.outputs.cloudfront_assets_version }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/build
@@ -48,10 +46,8 @@ jobs:
         run: pnpm check:type
 
   test:
-    needs: [generate-assets-version, lint-and-type-check]
+    needs: lint-and-type-check
     runs-on: ubuntu-latest
-    env:
-      CLOUDFRONT_ASSETS_VERSION: ${{ needs.generate-assets-version.outputs.cloudfront_assets_version }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/build
@@ -66,7 +62,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/build
-      - name: Authorize AWS
+      - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,9 +8,6 @@ on:
     branches:
       - main
 
-env:
-  GITHUB_CONTEXT: ${{ toJson(github) }}
-
 jobs:
   generate-assets-version:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,7 @@ jobs:
     needs: generate-assets-version
     runs-on: ubuntu-latest
     env:
+      GEN_ASSETS_OUTPUTS: ${{join(needs.generate-assets-version.outputs.*, '\n')}}
       CLOUDFRONT_ASSETS_VERSION: ${{ needs.generate-assets-version.outputs.cloudfront_assets_version }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,6 @@ jobs:
       run: pnpm test
 
     - name: Authorize AWS
-      if: github.ref == 'refs/heads/main' && github.repository_owner == 'peacefulseeker'
       uses: aws-actions/configure-aws-credentials@v1
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
         run: pnpm test
 
   deploy:
-    # if: github.ref == 'refs/heads/main' && github.repository_owner == 'peacefulseeker'
+    if: github.ref == 'refs/heads/main' && github.repository_owner == 'peacefulseeker'
     needs: [build, test]
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,20 +15,20 @@ jobs:
   generate-assets-version:
     runs-on: ubuntu-latest
     outputs:
-      cloudfront_assets_version: ${{ steps.set_version.outputs.version }}
+      cloudfront_assets_version: ${{ steps.set_version.outputs.cloudfront_assets_version }}
     steps:
       - uses: actions/checkout@v4
       - id: set_version
         run: |
           TIMESTAMP=$(date +%Y%m%d%H%M)
           VERSION=$(git rev-parse --short HEAD)
-          echo "version=${TIMESTAMP}_${VERSION}" >> $GITHUB_OUTPUT
+          echo "cloudfront_assets_version=${TIMESTAMP}_${VERSION}" >> $GITHUB_OUTPUT
 
   build:
     needs: generate-assets-version
     runs-on: ubuntu-latest
     env:
-      CLOUDFRONT_ASSETS_VERSION: ${{ needs.generate-version.outputs.cloudfront_assets_version }}
+      CLOUDFRONT_ASSETS_VERSION: ${{ needs.generate-assets-version.outputs.cloudfront_assets_version }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/build
@@ -37,7 +37,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     env:
-      CLOUDFRONT_ASSETS_VERSION: ${{ needs.generate-version.outputs.cloudfront_assets_version }}
+      CLOUDFRONT_ASSETS_VERSION: ${{ needs.generate-assets-version.outputs.cloudfront_assets_version }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/build
@@ -50,7 +50,7 @@ jobs:
     needs: lint-and-type-check
     runs-on: ubuntu-latest
     env:
-      CLOUDFRONT_ASSETS_VERSION: ${{ needs.generate-version.outputs.cloudfront_assets_version }}
+      CLOUDFRONT_ASSETS_VERSION: ${{ needs.generate-assets-version.outputs.cloudfront_assets_version }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/build
@@ -61,7 +61,7 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     env:
-      CLOUDFRONT_ASSETS_VERSION: ${{ needs.generate-version.outputs.cloudfront_assets_version }}
+      CLOUDFRONT_ASSETS_VERSION: ${{ needs.generate-assets-version.outputs.cloudfront_assets_version }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/build
@@ -73,4 +73,4 @@ jobs:
           aws-region: eu-central-1
       - name: Deploy to S3
         run: |
-          aws s3 sync dist/ s3://django-libraryms/v/${{ env.CLOUDFRONT_ASSETS_VERSION }} --delete --acl public-read
+          aws s3 sync dist/ s3://django-libraryms/v/${{ env.CLOUDFRONT_ASSETS_VERSION }} --acl public-read

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   generate-assets-version:
+    if: github.ref == 'refs/heads/main' && github.repository_owner == 'peacefulseeker'
     runs-on: ubuntu-latest
     outputs:
       cloudfront_assets_version: ${{ steps.set_version.outputs.cloudfront_assets_version }}
@@ -22,7 +23,8 @@ jobs:
           echo "cloudfront_assets_version=${TIMESTAMP}_${VERSION}" >> $GITHUB_OUTPUT
 
   build:
-    needs: generate-assets-version
+    needs:
+      - ${{ github.ref == 'refs/heads/main' && 'generate-assets-version' || '' }}
     runs-on: ubuntu-latest
     env:
       GEN_ASSETS_OUTPUTS: ${{join(needs.generate-assets-version.outputs.*, '\n')}}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,59 @@
+name: CI/CD Pipeline
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: 20.9.0
+
+    - name: Install pnpm
+      uses: pnpm/action-setup@v2
+      with:
+        version: 9.9.0
+
+    - name: Install dependencies
+      run: pnpm install
+
+    - name: Generate version number
+      id: version
+      run: echo "::set-output name=version::$(git rev-parse --short HEAD)"
+
+    - name: build
+      run: CLOUDFRONT_ASSETS_VERSION=${{ steps.version.outputs.version }} pnpm run build
+
+    - name: lint
+      run: pnpm run lint
+
+    - name: type check
+      run: pnpm run type-check
+
+    - name: Run tests
+      run: pnpm run test
+
+    - name: Authorize AWS
+      if: github.ref == 'refs/heads/main' && github.repository_owner == 'peacefulseeker'
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: eu-central-1
+
+    - name: Deploy to S3
+      run: |
+        VERSION=${{ steps.version.outputs.version }}
+        aws s3 sync dist/ s3://django-libraryms/v/$VERSION --delete --acl public-read
+        # aws cloudfront create-invalidation --distribution-id YOUR_DISTRIBUTION_ID --paths "/v/$VERSION/*"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,4 +52,6 @@ jobs:
           aws-region: eu-central-1
       - name: Deploy to S3
         run: |
-          aws s3 sync dist/ s3://django-libraryms/v/${{ env.CLOUDFRONT_ASSETS_VERSION }} --delete --acl public-read
+          TIMESTAMP=$(date +%Y%m%d%H%M)
+          VERSION=${TIMESTAMP}_${{ env.CLOUDFRONT_ASSETS_VERSION }}
+          aws s3 sync dist/ s3://django-libraryms/v/$VERSION --delete --acl public-read

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,6 +52,4 @@ jobs:
           aws-region: eu-central-1
       - name: Deploy to S3
         run: |
-          TIMESTAMP=$(date +%Y%m%d%H%M)
-          VERSION=${TIMESTAMP}_${{ env.CLOUDFRONT_ASSETS_VERSION }}
-          aws s3 sync dist/ s3://django-libraryms/v/$VERSION --delete --acl public-read
+          aws s3 sync dist/ s3://django-libraryms/v/${{ env.CLOUDFRONT_ASSETS_VERSION }} --delete --acl public-read

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,14 +15,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/build
 
   lint-and-type-check:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/build
       - name: Lint
         run: pnpm check:lint
@@ -33,7 +33,7 @@ jobs:
     needs: lint-and-type-check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/build
       - name: Run tests
         run: pnpm test
@@ -42,7 +42,8 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/build
       - name: Authorize AWS
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "dev": "vite",
         "build": "vite build",
         "preview": "vite preview",
-        "test": "vitest",
+        "test": "vitest run",
         "check:type": "vue-tsc --project tsconfig.app.json",
         "watch:type": "pnpm check:type --watch",
         "check:lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix --ignore-path .gitignore  --max-warnings=0",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "pnpm check:type && vite build",
+        "build": "vite build",
         "preview": "vite preview",
-        "test:unit": "vitest",
+        "test": "vitest",
         "check:type": "vue-tsc --project tsconfig.app.json",
         "watch:type": "pnpm check:type --watch",
         "check:lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix --ignore-path .gitignore  --max-warnings=0",

--- a/src/api/books.ts
+++ b/src/api/books.ts
@@ -1,13 +1,13 @@
 import axios from '@/axios';
 import type { Book, BookEnqueued, BookInList, BookReserved } from '@/types/books';
 
-type OrderResponse = {
+export type OrderResponse = {
   orderId: number;
   bookId: number;
   detail: string;
 };
 
-type ReservationExtendResponse = {
+export type ReservationExtendResponse = {
   detail: string;
 };
 

--- a/src/stores/book.spec.ts
+++ b/src/stores/book.spec.ts
@@ -1,0 +1,74 @@
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { cancelBookOrder, orderBook, type OrderResponse } from '@/api/books';
+import useBook from '@/stores/book';
+import type { Book } from '@/types/books';
+
+vi.mock('@/api/books', () => ({
+  orderBook: vi.fn(),
+  cancelBookOrder: vi.fn(),
+}));
+
+describe('useBook', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+
+    vi.stubGlobal('$toast', {
+      add: vi.fn(),
+    });
+  });
+
+  it('initializes with empty book', () => {
+    const store = useBook();
+    expect(store.book).toEqual({});
+  });
+
+  it('reservedByAnyone is queuable', () => {
+    const store = useBook();
+    store.book = { isAvailable: false } as Book;
+
+    expect(store.reservedByAnyone).toBe(true);
+    expect(store.queuable).toBe(true);
+  });
+
+  it('bookedByMember is not queuable', () => {
+    const store = useBook();
+    store.book = { isReservedByMember: true } as Book;
+
+    expect(store.bookedByMember).toBe(true);
+    expect(store.queuable).toBe(false);
+  });
+
+  it('book order action', async () => {
+    const store = useBook();
+    vi.mocked(orderBook).mockResolvedValue({ detail: 'Order successful' } as OrderResponse);
+    const toastAddSpy = vi.spyOn(window.$toast, 'add');
+
+    await store.order(1);
+
+    expect(orderBook).toHaveBeenCalledWith(1);
+    expect(toastAddSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: 'Order successful',
+        severity: 'success',
+      }),
+    );
+  });
+
+  it('book order cancel action', async () => {
+    const store = useBook();
+    const toastAddSpy = vi.spyOn(window.$toast, 'add');
+
+    await store.orderCancel(1);
+
+    expect(cancelBookOrder).toHaveBeenCalledWith(1);
+    expect(toastAddSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: 'Reservation cancelled',
+        severity: 'warn',
+      }),
+    );
+    expect(store.book).toEqual({});
+  });
+});

--- a/src/style.css
+++ b/src/style.css
@@ -155,8 +155,3 @@ main {
 .spinner-form {
   @apply absolute h-full w-full;
 }
-
-
-body {
-  background: coral !important;
-}

--- a/src/style.css
+++ b/src/style.css
@@ -155,3 +155,8 @@ main {
 .spinner-form {
   @apply absolute h-full w-full;
 }
+
+
+body {
+  background: coral !important;
+}

--- a/src/types/toast.ts
+++ b/src/types/toast.ts
@@ -1,4 +1,5 @@
 import { type ToastServiceMethods } from 'primevue/toastservice';
+
 declare global {
   interface Window {
     $toast: ToastServiceMethods;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -36,20 +36,11 @@ const viteConfig = defineConfig({
   },
   experimental: {
     renderBuiltUrl(filename) {
-      // renderBuiltUrl(filename, { hostId, hostType, type }) {
-      if (process.env.CLOUDFRONT_ASSETS_VERSION) {
-        // if (hostType === 'html') {
-        // filename = filename.replace(/-[a-zA-Z0-9]+\.(js|css)$/, '.$1');
-        //   console.log({ filename, hostId, hostType, type });
-        //   console.log('====');
-        // }
-
-        filename =
-          `https://d1nvb8emsymmvr.cloudfront.net/v/${process.env.CLOUDFRONT_ASSETS_VERSION}/` +
-          filename;
-        return filename;
-      }
-      if (filename.indexOf('/assets/') !== -1) {
+      const assetsVersion = process.env.CLOUDFRONT_ASSETS_VERSION;
+      if (assetsVersion) {
+        // TODO: define CDN host in a template dynamically
+        return `https://d1nvb8emsymmvr.cloudfront.net/v/${assetsVersion}/` + filename;
+      } else if (filename.indexOf('/assets/') !== -1) {
         return '/static/frontend/assets/' + filename.replace(/^assets\//, '');
       }
       return '/static/frontend/' + filename;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,9 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vite';
 import { fileURLToPath, URL } from 'node:url';
-import vue from '@vitejs/plugin-vue';
 
+import { defineConfig } from 'vite';
+
+import vue from '@vitejs/plugin-vue';
 
 // const dockerPort = 7004;
 const localPort = 7070;
@@ -14,9 +15,7 @@ const viteConfig = defineConfig({
       '/api': `http://127.0.0.1:${localPort}`,
     },
   },
-  plugins: [
-    vue(),
-  ],
+  plugins: [vue()],
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url)),
@@ -24,12 +23,19 @@ const viteConfig = defineConfig({
   },
   experimental: {
     renderBuiltUrl(filename) {
-        if (filename.indexOf('/assets/') !== -1) {
-          return '/static/frontend/assets/' + filename.replace(/^assets\//, '');
-        }
-        return '/static/frontend/' + filename;
+      if (process.env.CLOUDFRONT_ASSETS_VERSION) {
+        filename =
+          `https://d1nvb8emsymmvr.cloudfront.net/v/${process.env.CLOUDFRONT_ASSETS_VERSION}/` +
+          filename;
+        console.log(filename);
+        return filename;
+      }
+      if (filename.indexOf('/assets/') !== -1) {
+        return '/static/frontend/assets/' + filename.replace(/^assets\//, '');
+      }
+      return '/static/frontend/' + filename;
     },
-  }
+  },
 });
 
 export default viteConfig;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,13 +21,32 @@ const viteConfig = defineConfig({
       '@': fileURLToPath(new URL('./src', import.meta.url)),
     },
   },
+  build: {
+    rollupOptions: {
+      output: {
+        entryFileNames: 'assets/index.js',
+        assetFileNames: (assetInfo) => {
+          if (assetInfo.name === 'index.css') {
+            return 'assets/index.css';
+          }
+          return 'assets/[name].[ext]';
+        },
+      },
+    },
+  },
   experimental: {
     renderBuiltUrl(filename) {
+      // renderBuiltUrl(filename, { hostId, hostType, type }) {
       if (process.env.CLOUDFRONT_ASSETS_VERSION) {
+        // if (hostType === 'html') {
+        // filename = filename.replace(/-[a-zA-Z0-9]+\.(js|css)$/, '.$1');
+        //   console.log({ filename, hostId, hostType, type });
+        //   console.log('====');
+        // }
+
         filename =
           `https://d1nvb8emsymmvr.cloudfront.net/v/${process.env.CLOUDFRONT_ASSETS_VERSION}/` +
           filename;
-        console.log(filename);
         return filename;
       }
       if (filename.indexOf('/assets/') !== -1) {


### PR DESCRIPTION
Basic CI/CD pipeline with build/lint/type-check/test and deploy steps.
On every deployment, a unique version will be generated for assets and the contents
of `/dist` folder will be put to the s3 bucket /v/{$version/ accordingly.

### Notes
- generating `index.css` and `index.html` during build without hashes allows 
referencing assets by specifying 1 dynamic component only -> assets version
https://github.com/peacefulseeker/django-libraryms/pull/34/files#diff-efd29cce75c4e6efb80503117e83ec5fc798a0d3a71d29edd04b2eb71d4c2cca
- essentially, after each deployment in the current repo, the newly generated version, e.g. `202409041619_be0a26b`
can be set to a secret variable in the backend app and a new version will be served from cloudfront CDN.

**TODO**: write the latest or last 5 latest versions to the repo root, e.g. in a text file. 
This way, could quickly check what versions could be deployed/compared.