### PR TITLE
Conditional config + dynamic CDN url + GH release job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,7 +74,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          TAG_NAME="v${{ needs.deploy.outputs.cloudfront_assets_version }}"
+          TAG_NAME="${{ needs.deploy.outputs.cloudfront_assets_version }}"
           gh release create $TAG_NAME \
             --title "Release $TAG_NAME" \
             --notes "Automated release for version $TAG_NAME" \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,6 +66,8 @@ jobs:
   create-release:
     needs: deploy
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - name: Create release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,11 +43,13 @@ jobs:
         run: pnpm test
 
   deploy:
-    if: github.ref == 'refs/heads/main' && github.repository_owner == 'peacefulseeker'
+    # if: github.ref == 'refs/heads/main' && github.repository_owner == 'peacefulseeker'
     needs: [build, test]
     runs-on: ubuntu-latest
     env:
       CLOUDFRONT_ASSETS_VERSION: ${{ needs.build.outputs.cloudfront_assets_version }}
+    outputs:
+      cloudfront_assets_version: ${{ env.CLOUDFRONT_ASSETS_VERSION }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/build
@@ -60,3 +62,18 @@ jobs:
       - name: Deploy to S3
         run: |
           aws s3 sync dist/ s3://django-libraryms/v/${{ env.CLOUDFRONT_ASSETS_VERSION }} --acl public-read
+
+  create-release:
+    needs: deploy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG_NAME="v${{ needs.deploy.outputs.cloudfront_assets_version }}"
+          gh release create $TAG_NAME \
+            --title "Release $TAG_NAME" \
+            --notes "Automated release for version $TAG_NAME" \
+            --target ${{ github.sha }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
         run: pnpm test
 
   deploy:
-    # if: github.ref == 'refs/heads/main' && github.repository_owner == 'peacefulseeker'
+    if: github.ref == 'refs/heads/main' && github.repository_owner == 'peacefulseeker'
     needs: [build, test]
     runs-on: ubuntu-latest
     env:

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
     "private": true,
     "type": "module",
     "scripts": {
-        "dev": "vite",
+        "dev": "API_PROXY_PORT=7070 vite",
         "build": "vite build",
-        "preview": "vite preview",
+        "preview": "vite preview --open",
+        "preview:build": "VITE_PREVIEW=1 vite build",
         "test": "vitest run",
         "check:type": "vue-tsc --project tsconfig.app.json",
         "watch:type": "pnpm check:type --watch",


### PR DESCRIPTION
- specifies API proxy port in the `dev` script
- Mark vite preview with env variable to exclude custom build/experimental logic
- `__toFrontendAssetsUrl` is expected to exist in template(`vue-index.html` which will define the final
assets URL(local or CND one based on configs). https://github.com/peacefulseeker/django-libraryms/commit/9589cd04795565f7b153d9053e925c35a771da28
- add `create-release` job which will publish the release after successful deploy with the version of the asset as a tag name. This will bring visibility around versions and related logic released over time.